### PR TITLE
conflict about function isxdigit()

### DIFF
--- a/libraries/cli/cli.cpp
+++ b/libraries/cli/cli.cpp
@@ -1,15 +1,15 @@
 #include <bts/cli/cli.hpp>
 #include <fc/thread/thread.hpp>
 
-#ifndef WIN32
-#include <readline/readline.h>
-#include <readline/history.h>
-#endif //!WIN32
-
 #include <iostream>
 #include <sstream>
 
 #include <fc/log/logger.hpp>
+
+#ifndef WIN32
+#include <readline/readline.h>
+#include <readline/history.h>
+#endif //!WIN32
 
 namespace bts { namespace cli {
    


### PR DESCRIPTION
conflict about function isxdigit()
it's define in both readline.h and iostream
have to include readline.h after include iostream

when I compile, I get error message:
In file included from /usr/include/c++/4.8/bits/basic_ios.h:37:0,
                 from /usr/include/c++/4.8/ios:44,
                 from /usr/include/c++/4.8/ostream:38,
                 from /usr/include/c++/4.8/iostream:39,
                 from /home/alt/workspace/bitshares_toolkit/libraries/cli/cli.cpp:9:
/usr/include/c++/4.8/bits/locale_facets.h:2578:45: error: macro "isxdigit" passed 2 arguments, but takes just 1
     isxdigit(_CharT __c, const locale& __loc)
