### PR TITLE
improve wallet's scan_input API

### DIFF
--- a/libraries/wallet/include/bts/wallet/wallet.hpp
+++ b/libraries/wallet/include/bts/wallet/wallet.hpp
@@ -152,7 +152,7 @@ namespace wallet {
         protected:
            virtual void dump_output( const trx_output& out );
            virtual bool scan_output( transaction_state& state, const trx_output& out, const output_reference& ref, const output_index& idx );
-           virtual void scan_input( transaction_state& state, const output_reference& ref );
+           virtual void scan_input( transaction_state& state, const output_reference& ref, const output_index& idx );
            virtual void cache_output( const trx_output& out, const output_reference& ref, const output_index& idx );
 
         private:

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -631,26 +631,22 @@ namespace bts { namespace wallet {
       return my->_data.transactions;
    }
 
-   void wallet::scan_input( transaction_state& state, const output_reference& r )
+   void wallet::scan_input( transaction_state& state, const output_reference& r, const output_index& idx )
    {
-      auto ref_itr = my->_output_ref_to_index.find(r);
-      if( ref_itr == my->_output_ref_to_index.end() ) 
+      auto itr = my->_data.unspent_outputs.find(idx);
+      if( itr != my->_data.unspent_outputs.end() )
       {
+         state.adjust_balance( itr->second.amount, -1 );
+         return;
+      }
+      itr = my->_data.spent_outputs.find(idx);
+      if( itr != my->_data.unspent_outputs.end() )
+      {
+         state.adjust_balance( itr->second.amount, -1 );
          return;
       }
 
-      auto itr = my->_data.unspent_outputs.find(ref_itr->second);
-      if( itr != my->_data.unspent_outputs.end() )
-      {
-         state.adjust_balance( itr->second.amount, -1 );
-         return;
-      }
-      itr = my->_data.spent_outputs.find( ref_itr->second );
-      if( itr != my->_data.unspent_outputs.end() )
-      {
-         state.adjust_balance( itr->second.amount, -1 );
-         return;
-      }
+      mark_as_spent( r);
    }
 
    bool wallet::scan_transaction( transaction_state& state, uint32_t block_idx, uint32_t trx_idx )
@@ -658,8 +654,12 @@ namespace bts { namespace wallet {
        bool found = false;
        for( uint32_t in_idx = 0; in_idx < state.trx.inputs.size(); ++in_idx )
        {
-           scan_input( state, state.trx.inputs[in_idx].output_ref );
-           mark_as_spent( state.trx.inputs[in_idx].output_ref );
+           auto ref_itr = my->_output_ref_to_index.find(state.trx.inputs[in_idx].output_ref);
+           if( ref_itr == my->_output_ref_to_index.end() ) 
+           {
+              continue;
+           }
+           scan_input( state,  state.trx.inputs[in_idx].output_ref, ref_itr->second);
        }
 
        // for each output


### PR DESCRIPTION
Today I intent to override wallet's scan_input method, because I do not want to adjust the balance if input's out_ref is claim_ticket_output,

But I found that input's output, my->_output_ref_to_index is private, so in's output cannot be accessed from derived class lotto_wallet with current API.

This pull request is to improve the scan_input api to keep similar approach with scan_output, added extra parameter(const output_index& idx), then claim_func can be identified.

https://github.com/HackFisher/bitshares_toolkit/blob/lotto_experi/libraries/lotto/lotto_wallet.cpp
