### PR TITLE
support overrite/customize generate blocks, from lotto requirements

### DIFF
--- a/libraries/blockchain/include/bts/blockchain/chain_database.hpp
+++ b/libraries/blockchain/include/bts/blockchain/chain_database.hpp
@@ -13,6 +13,14 @@ namespace bts { namespace blockchain {
 
     namespace detail  { class chain_database_impl; }
 
+    struct genesis_block_config
+    {
+        genesis_block_config() :supply(0), blockheight(0){}
+        double                                            supply;
+        uint64_t                                          blockheight;
+        std::vector< std::pair<bts::blockchain::pts_address, double> > balances;
+    };
+
     struct name_record
     {
        name_record()
@@ -69,6 +77,7 @@ namespace bts { namespace blockchain {
           chain_database();
           virtual ~chain_database();
 
+          virtual bts::blockchain::trx_block create_test_genesis_block(fc::path genesis_json_file);
           /**
            *  There are many kinds of deterministic transactions that various blockchains may require
            *  such as automatic inactivity fees, lottery winners, and market making.   This method
@@ -164,4 +173,5 @@ namespace bts { namespace blockchain {
 
 FC_REFLECT( bts::blockchain::trx_num,  (block_num)(trx_idx) );
 FC_REFLECT( bts::blockchain::name_record, (delegate_id)(name)(data)(owner)(votes_for)(votes_against) )
+FC_REFLECT( bts::blockchain::genesis_block_config, (supply)(balances) )
 

--- a/libraries/net/chain_server.cpp
+++ b/libraries/net/chain_server.cpp
@@ -26,123 +26,6 @@ using namespace bts::blockchain;
 
 namespace bts { namespace net {
 
-/**
- *  When creating the genesis block it must initialize the genesis block to vote
- *  evenly for the top 100 delegates and register the top 100 delegates.
- */
-bts::blockchain::trx_block create_test_genesis_block(fc::path genesis_json_file)
-{
-   try {
-      FC_ASSERT( fc::exists(genesis_json_file) );
-      auto config = fc::json::from_file(genesis_json_file).as<genesis_block_config>();
-      bts::blockchain::trx_block b;
-
-      signed_transaction dtrx;
-      dtrx.vote = 0;
-      // create initial delegates
-      for( uint32_t i = 0; i < 100; ++i )
-      {
-         auto name     = "delegate-"+fc::to_string( int64_t(i+1) );
-         auto key_hash = fc::sha256::hash( name.c_str(), name.size() );
-         auto key      = fc::ecc::private_key::regenerate(key_hash);
-         dtrx.outputs.push_back( trx_output( claim_name_output( name, std::string(), i+1, key.get_public_key() ), asset() ) );
-      }
-      b.trxs.push_back( dtrx );
-
-
-      bts::blockchain::signed_transaction coinbase;
-      coinbase.version = 0;
-
-      // TODO: simplify to one output per tx and evenly allocate votes among delegates
-      uint8_t output_idx = 0;
-      int32_t  current_delegate = 0;
-      uint64_t total_votes = 0;
-      uint64_t total = 0;
-      for( auto itr = config.balances.begin(); itr != config.balances.end(); ++itr )
-      {
-          itr->second *=  100000000;;
-          total += itr->second;
-      }
-      FC_ASSERT(total >= 100, "genesis block must contain enough balances to distribute amongst the delegates");
-      int64_t one_percent = total / 100;
-      elog( "one percent: ${one}", ("one",one_percent) );
-
-
-      int64_t cur_trx_total = 0;
-      int64_t total_supply = 0;
-      for( auto itr = config.balances.begin(); itr != config.balances.end(); ++itr )
-      {
-         auto delta = one_percent - cur_trx_total;
-         if( delta > itr->second )
-         {
-            coinbase.outputs.push_back( trx_output( claim_by_pts_output( itr->first ), asset( itr->second ) ) );
-            cur_trx_total += itr->second;
-         }
-         else
-         {
-            coinbase.outputs.push_back( trx_output( claim_by_pts_output( itr->first ), asset( delta ) ) );
-            cur_trx_total += delta;
-            total_supply += cur_trx_total;
-            coinbase.vote = ((total_supply / one_percent)%100)+1;
-            ilog( "vote: ${v}", ("v",coinbase.vote) );
-
-            b.trxs.emplace_back( std::move(coinbase) );
-            coinbase.outputs.clear();
-            cur_trx_total = 0;
-
-            int64_t change = itr->second - delta;
-            while( change >= one_percent )
-            {
-               coinbase.outputs.push_back( trx_output( claim_by_pts_output( itr->first ), asset( one_percent ) ) );
-               total_supply += one_percent;
-               coinbase.vote = ((total_supply / one_percent)%100)+1;
-               ilog( "vote: ${v}", ("v",coinbase.vote) );
-               b.trxs.emplace_back( coinbase );
-               coinbase.outputs.clear();
-               change -= one_percent;
-               cur_trx_total = 0;
-            }
-            if( change != 0 )
-            {
-               coinbase.outputs.push_back( trx_output( claim_by_pts_output( itr->first ), asset( change ) ) );
-               cur_trx_total = change;
-            }
-         }
-         if( coinbase.outputs.size() == 0xff )
-         {
-            coinbase.vote = ((total_supply / one_percent)%100)+1;
-            b.trxs.emplace_back( coinbase );
-            coinbase.outputs.clear();
-         }
-      }
-      if( coinbase.outputs.size() )
-      {
-         coinbase.vote = ((total_supply / one_percent)%100)+1;
-         ilog( "vote: ${v}", ("v",coinbase.vote) );
-         b.trxs.emplace_back( coinbase );
-         coinbase.outputs.clear();
-      }
-
-      b.version         = 0;
-      b.block_num       = 0;
-      b.prev            = bts::blockchain::block_id_type();
-      b.timestamp       = fc::time_point::now();
-      b.next_fee        = bts::blockchain::block_header::min_fee();
-      b.total_shares    = int64_t(total_supply);
-
-      b.trx_mroot   = b.calculate_merkle_root(signed_transactions());
-
-      //auto str = fc::json::to_pretty_string(var); //b);
-      //ilog( "block: \n${b}", ("b", str ) );
-      return b;
-   }
-   catch ( const fc::exception& e )
-   {
-      ilog( "caught exception!: ${e}", ("e", e.to_detail_string()) );
-      throw;
-   }
-}
-
 namespace detail
 {
    class chain_server_impl : public chain_connection_delegate
@@ -440,7 +323,7 @@ void chain_server::configure( const chain_server::config& c )
      my->_chain->open( "chain" );
      if( my->_chain->head_block_num() == uint32_t(-1) )
      {
-         auto genesis = create_test_genesis_block("genesis.json");
+         auto genesis = my->_chain->create_test_genesis_block("genesis.json");
          ilog( "about to push" );
          try {
             //ilog( "genesis block: \n${s}", ("s", fc::json::to_pretty_string(genesis) ) );

--- a/libraries/net/include/bts/net/chain_server.hpp
+++ b/libraries/net/include/bts/net/chain_server.hpp
@@ -15,21 +15,9 @@ namespace bts { namespace net {
 
   class connection;
   typedef std::shared_ptr<chain_connection> connection_ptr;
-
-
-
-  struct genesis_block_config
-  {
-     genesis_block_config():supply(0),blockheight(0){}
-     double                                            supply;
-     uint64_t                                          blockheight;
-     std::vector< std::pair<bts::blockchain::pts_address,double> > balances;
-  };
 } } // bts::net
-FC_REFLECT( bts::net::genesis_block_config, (supply)(balances) )
-namespace bts { namespace net {
-  bts::blockchain::trx_block create_test_genesis_block(fc::path genesis_json_file);
 
+namespace bts { namespace net {
   /**
    * @brief defines the set of callbacks that a server provides.
    *

--- a/libraries/wallet/include/bts/wallet/wallet.hpp
+++ b/libraries/wallet/include/bts/wallet/wallet.hpp
@@ -121,14 +121,6 @@ namespace wallet {
 
            void import_bitcoin_wallet( const fc::path& dir, const std::string& passphrase );
 
-          /** Given a set of user-provided transactions, this method will generate a block that
-           * uses transactions prioritized by fee up until the maximum size.  Invalid transactions
-           * are ignored and not included in the set.
-           *
-           * @note some transaction may be valid stand-alone, but may conflict with other transactions.
-           */
-           trx_block                               generate_next_block( chain_database& db, const signed_transactions& trxs);
-
            address                                 import_key( const fc::ecc::private_key& key, const std::string& label = "" );
            address                                 new_receive_address( const std::string& label = "" );
            fc::ecc::public_key                     new_public_key( const std::string& label = "" );
@@ -195,6 +187,14 @@ namespace wallet {
            signed_transaction collect_inputs_and_sign(signed_transaction& trx, const asset& min_amnt);
 
            std::string                         get_transaction_info_string(bts::blockchain::chain_database& db, const transaction& tx);
+
+           /** Given a set of user-provided transactions, this method will generate a block that
+           * uses transactions prioritized by fee up until the maximum size.  Invalid transactions
+           * are ignored and not included in the set.
+           *
+           * @note some transaction may be valid stand-alone, but may conflict with other transactions.
+           */
+           virtual trx_block generate_next_block(chain_database& db, const signed_transactions& trxs);
            virtual std::string                 get_output_info_string(const trx_output& out);
            virtual std::string                 get_input_info_string(bts::blockchain::chain_database& db, const trx_input& in);
 

--- a/programs/bts_xt/main.cpp
+++ b/programs/bts_xt/main.cpp
@@ -223,7 +223,7 @@ bts::blockchain::chain_database_ptr load_and_configure_chain_database(const fc::
       bts::blockchain::trx_block genesis_block;
       try
       {
-        genesis_block = bts::net::create_test_genesis_block(genesis_json_file);
+          genesis_block = chain->create_test_genesis_block(genesis_json_file);
       }
       catch (fc::exception& e)
       {

--- a/programs/dns/main.cpp
+++ b/programs/dns/main.cpp
@@ -228,7 +228,7 @@ std::shared_ptr<bts::dns::dns_db> load_and_configure_chain_database(const fc::pa
       bts::blockchain::trx_block genesis_block;
       try
       {
-        genesis_block = bts::net::create_test_genesis_block(genesis_json_file);
+        genesis_block = db->create_test_genesis_block(genesis_json_file);
       }
       catch (fc::exception& e)
       {

--- a/tests/bts_xt_client_tests.cpp
+++ b/tests/bts_xt_client_tests.cpp
@@ -169,11 +169,11 @@ void managed_process::log_stdout_stderr_to_file(const fc::path& logfile)
 
 struct bts_server_process : managed_process
 {
-  void launch(const bts::net::genesis_block_config& genesis_block, const fc::ecc::private_key& trustee_key);
+  void launch(const bts::blockchain::genesis_block_config& genesis_block, const fc::ecc::private_key& trustee_key);
 };
 typedef std::shared_ptr<bts_server_process> bts_server_process_ptr;
 
-void bts_server_process::launch(const bts::net::genesis_block_config& genesis_block,
+void bts_server_process::launch(const bts::blockchain::genesis_block_config& genesis_block,
                                 const fc::ecc::private_key& trustee_key)
 {
   process = std::make_shared<fc::process>();
@@ -217,14 +217,14 @@ struct bts_client_process : managed_process
   void launch(uint32_t process_number, 
               const fc::ecc::private_key& trustee_key, 
               bool act_as_trustee,
-              fc::optional<bts::net::genesis_block_config> genesis_block);
+              fc::optional<bts::blockchain::genesis_block_config> genesis_block);
 };
 typedef std::shared_ptr<bts_client_process> bts_client_process_ptr;
 
 void bts_client_process::launch(uint32_t process_number, 
                                 const fc::ecc::private_key& trustee_key, 
                                 bool act_as_trustee,
-                                fc::optional<bts::net::genesis_block_config> genesis_block)
+                                fc::optional<bts::blockchain::genesis_block_config> genesis_block)
 {
   process = std::make_shared<fc::process>();
   std::vector<std::string> options;
@@ -297,7 +297,7 @@ struct bts_client_launcher_fixture
   bts_server_process_ptr server_process;
   std::vector<bts_client_process> client_processes;
 
-  bts::net::genesis_block_config genesis_block;
+  bts::blockchain::genesis_block_config genesis_block;
   fc::ecc::private_key trustee_key = fc::ecc::private_key::generate();
 
   //const uint32_t test_process_count = 10;
@@ -338,7 +338,7 @@ void bts_client_launcher_fixture::launch_clients()
   {
     client_processes[i].rpc_port = bts_xt_client_test_config::base_rpc_port + i;
     client_processes[i].p2p_port = bts_xt_client_test_config::base_p2p_port + i;
-    fc::optional<bts::net::genesis_block_config> optional_genesis_block;
+    fc::optional<bts::blockchain::genesis_block_config> optional_genesis_block;
     if (i == 0 && !bts_xt_client_test_config::test_client_server)
       optional_genesis_block = genesis_block;
     client_processes[i].launch(i, trustee_key, i == 0, 


### PR DESCRIPTION
Lotto have requirement that miner need to generate/add info (secret, revealed_secret) as transaction, and add to blocks.

So to support override "create_test_genesis_block" and "generate_next_block".
