### PR TITLE
deterministic_trxs ids should be stored

### DIFF
--- a/libraries/blockchain/chain_database.cpp
+++ b/libraries/blockchain/chain_database.cpp
@@ -231,10 +231,7 @@ namespace bts { namespace blockchain {
                 for( const signed_transaction& trx : deterministic_trxs )
                 {
                    store( trx, trx_num( b.block_num, trxs_ids.size() ) );
-                   // TODO: why don't we include this here... do determinsitic trxs not
-                   // get included in the merkel root... does this hinder light weight
-                   // clients.
-                  // trxs_ids.push_back( trx.id() );
+                   trxs_ids.push_back( trx.id() );
                 }
                 head_block    = b;
                 head_block_id = b.id();


### PR DESCRIPTION
As they are also included in merkle root, and for light clients, they do not need to handle deterministic trxs, only need to valid that.

And there was a bug before that.
