### PR TITLE
Fix new address not saved issue

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -569,12 +569,15 @@ namespace bts { namespace wallet {
 
    address   wallet::new_receive_address( const std::string& memo, const std::string& account )
    { try {
-      return address( new_public_key( memo, account ) );
+	   address newaddr = new_public_key(memo, account);
+	   save();
+	   return newaddr;
    } FC_RETHROW_EXCEPTIONS( warn, "unable to create new address with memo '${memo}'", ("memo",memo) ) }
 
    void wallet::add_send_address( const address& addr, const std::string& label )
    { try {
       my->_data.send_addresses[addr] = label;
+	  save();
    } FC_RETHROW_EXCEPTIONS( warn, "unable to add send address ${addr} with label ${label}", 
                                    ("addr",addr)("label",label) ) }
 


### PR DESCRIPTION
Save the new address to wallet immediately after issue the command
"getnewaddress" and "add_send_address" which could prevent not saving
the new address to wallet if the client aborted abnornally(not via
"quit" command)
