### PR TITLE
Fix build error under windows

### DIFF
--- a/tests/chain_tests.cpp
+++ b/tests/chain_tests.cpp
@@ -7,6 +7,7 @@
 #include <fc/log/logger.hpp>
 #include <fc/io/json.hpp>
 #include <fc/thread/thread.hpp>
+#include <iostream>
 
 using namespace bts::blockchain;
 using namespace bts::wallet;


### PR DESCRIPTION
Error 45 error C2039: 'cerr' : is not a member of 'std'
