### PR TITLE
Fixed #107 getinfo do not work from cli

### DIFF
--- a/libraries/rpc/rpc_server.cpp
+++ b/libraries/rpc/rpc_server.cpp
@@ -597,7 +597,9 @@ Result:
                                      /* returns: */    "info",
                                      /* params:          name                 type      required */
                                                        { },
-                                   /* prerequisites */ 0, 
+                                   /* prerequisites */ 0,
+                                   R"(
+                                       )",
                                     /* aliases */ { "getinfo" } } ;
     fc::variant rpc_server_impl::get_info(const fc::variants& /*params*/)
     {


### PR DESCRIPTION
aliases is the last property after detailed description, so previous parameters should be provided before using aliases
