### PR TITLE
Resolve wallet cache when chain switch fork, if following with existing design,  related to #133

### DIFF
--- a/libraries/blockchain/chain_database.cpp
+++ b/libraries/blockchain/chain_database.cpp
@@ -645,6 +645,8 @@ namespace bts { namespace blockchain {
          _head_block_id = previous_block_id;
          _head_block_header = self->get_block_header( _head_block_id );
 
+         if( _observer ) _observer->state_changed(undo_state.shared_from_this());
+
       } FC_RETHROW_EXCEPTIONS( warn, "" ) }
 
    } // namespace detail

--- a/libraries/blockchain/include/bts/blockchain/pending_chain_state.hpp
+++ b/libraries/blockchain/include/bts/blockchain/pending_chain_state.hpp
@@ -3,7 +3,7 @@
 
 namespace bts { namespace blockchain {
 
-   class pending_chain_state : public chain_interface
+   class pending_chain_state : public chain_interface, public std::enable_shared_from_this<pending_chain_state>
    {
       public:
          pending_chain_state( chain_interface_ptr prev_state = chain_interface_ptr() );


### PR DESCRIPTION
Resolve partial issue described in #133.

For wallet export/import, still need to re-scan the chain to update the wallet cache, 
`wallet_export_to_json` and `wallet_create_from_json`
