### PR TITLE
wallet_api.json has 4 missing commas, manual fix.

### DIFF
--- a/libraries/api/wallet_api.json
+++ b/libraries/api/wallet_api.json
@@ -107,7 +107,7 @@
         "parameters" : [
            {
               "name" : "wallet_filename",
-              "type" : "filename"
+              "type" : "filename",
               "description" : "the path to the bitcoin wallet you would like to import."
            },
            {
@@ -130,7 +130,7 @@
         "parameters" : [
            {
               "name" : "wallet_filename",
-              "type" : "filename"
+              "type" : "filename",
               "description" : "the armory wallet"
            },
            {
@@ -153,7 +153,7 @@
         "parameters" : [
            {
               "name" : "wallet_filename",
-              "type" : "filename"
+              "type" : "filename",
               "description" : "the electrum wallet"
            },
            {
@@ -176,7 +176,7 @@
         "parameters" : [
            {
               "name" : "wallet_filename",
-              "type" : "filename"
+              "type" : "filename",
               "description" : "the multibit wallet"
            },
            {


### PR DESCRIPTION
wallet_api.json has 4 missing commas.
- wallet_import_multibit
- wallet_import_electrum
- wallet_import_armory
- wallet_import_bitcoin

the

"type" : "filename" 

part misses a comma at the end.
