### PR TITLE
Update BUILD_OSX.md

### DIFF
--- a/BUILD_OSX.md
+++ b/BUILD_OSX.md
@@ -52,7 +52,6 @@ Building BitShares Toolkit on OS X 10.9
     cd bitshares_toolkit
     git submodule init
     git submodule update
-    cd programs
     cmake -DCMAKE_PREFIX_PATH=/usr/local/ssl .
     make
 


### PR DESCRIPTION
 cd programs delete..

cause an build error if make is executed on bitshares_toolkit/programs
