### PR TITLE
Add command to delete old htdocs to build instructions

### DIFF
--- a/BUILD_UBUNTU.md
+++ b/BUILD_UBUNTU.md
@@ -18,6 +18,7 @@ For the Qt Wallet, some extra steps are required:
 	sudo npm install -g lineman
 	npm install
 	cd -
+	rm -Rf programs/web_wallet/generated programs/qt_wallet/htdocs
 	make buildweb
 	make BitSharesXT
 


### PR DESCRIPTION
The `make buildweb` command does not regenerate the web assets when their sources have changed.  We should really list the actual dependencies properly in the build system, or if that's too hard we should change the `make buildweb` target to delete the generated assets.

I'm not a cmake expert, though, so the only patch I've come up with is adding a command to the build instructions to tell the user to do it manually.

I filed https://github.com/BitShares/web_wallet/issues/301 unnecessarily because I was using old assets.  Hopefully this patch will prevent additional user aggravation and bug reports for already-fixed issues.
