### PR TITLE
utility to convert bitcoin pubkey into btsx pubkey

### DIFF
--- a/programs/utils/CMakeLists.txt
+++ b/programs/utils/CMakeLists.txt
@@ -27,3 +27,6 @@ target_link_libraries( map_bts_network fc bts_net bts_client)
 
 add_executable( pack_web pack_web.cpp )
 target_link_libraries( pack_web fc )
+
+add_executable( convert_btc_pubkey convert_btc_pubkey.cpp )
+target_link_libraries( convert_btc_pubkey fc bts_blockchain bts_utilities)

--- a/programs/utils/convert_btc_pubkey.cpp
+++ b/programs/utils/convert_btc_pubkey.cpp
@@ -1,0 +1,36 @@
+#include <bts/blockchain/address.hpp>
+#include <bts/blockchain/pts_address.hpp>
+#include <bts/blockchain/types.hpp>
+#include <bts/utilities/key_conversion.hpp>
+#include <fc/crypto/base58.hpp>
+#include <fc/crypto/openssl.hpp>
+#include <fc/crypto/elliptic.hpp>
+#include <fc/reflect/variant.hpp>
+#include <fc/crypto/hex.hpp>
+#include <fc/io/raw.hpp>
+#include <iostream>
+#include <fstream>
+
+
+#include <assert.h>
+
+using namespace bts::blockchain;
+
+int main( int argc, char** argv )
+{
+ if( argc == 1 )
+ {
+  std::cout << "usage: convert_btc_pubkey <btc public key | not address>" <<"\n";
+ }
+ else
+ {
+  fc::array<char, 65> data;
+  fc::ecc::public_key_data mypubkey;
+  std::string myarg = argv[1];
+  fc::from_hex(myarg, (char*)&data, sizeof(data) );
+  memcpy( (char*)mypubkey.data, data.data, sizeof(mypubkey) );
+  std::cout << "Please verify the Bitcoin address:\n";
+  std::cout << "BTC Address (compressed):  " << std::string(pts_address( mypubkey, true, 0 )) <<"\n";
+  std::cout << "BTSX public key:        :  " << std::string(public_key_type(mypubkey)) <<"\n";
+ }
+}


### PR DESCRIPTION
A small tool that allows to generate the btsx pubkey from a bitcoin pubkey

Application: You know a guy that has a bitcoin address .. you want to register a name for him and send him some bitUSD. Using the pubkey from his btc address he can import his account just by using his private key
