### PR TITLE
Implement verify_signature RPC

### DIFF
--- a/libraries/api/blockchain_api.json
+++ b/libraries/api/blockchain_api.json
@@ -689,6 +689,31 @@
         "parameters" : [],
         "is_const" : true,
         "prerequisites" : ["no_prerequisites"]
+      },
+      {
+        "method_name": "blockchain_verify_signature",
+        "description": "Verify that the given signature proves the given hash was signed by the given account.",
+        "return_type": "bool",
+        "parameters" : [
+            {
+                "name" : "signing_account",
+                "type" : "string",
+                "description" : "The account the signature claims to be from"
+            },
+            {
+                "name" : "hash",
+                "type" : "sha256",
+                "description" : "The hash the signature claims to be for"
+            },
+            {
+                "name" : "signature",
+                "type" : "compact_signature",
+                "description" : "A signature produced by wallet_sign_hash"
+            }
+        ],
+        "is_const"   : true,
+        "prerequisites" : ["no_prerequisites"],
+        "aliases" : ["verify_signature", "verify_sig", "blockchain_verify_sig"]
       }
     ]
 }

--- a/libraries/client/client.cpp
+++ b/libraries/client/client.cpp
@@ -3772,6 +3772,18 @@ config load_config( const fc::path& datadir, bool enable_ulog )
           return _chain_db->get_block_signee( std::stoi( block ) ).name;
    }
 
+   bool client_impl::blockchain_verify_signature(const string& signing_account, const fc::sha256& hash, const fc::ecc::compact_signature& signature) const
+   {
+      oaccount_record rec = blockchain_get_account(signing_account);
+      if (!rec.valid())
+        return false;
+
+      // logic shamelessly copy-pasted from signed_block_header::validate_signee()
+      // NB LHS of == operator is bts::blockchain::public_key_type and RHS is fc::ecc::public_key,
+      //   the opposite order won't compile (look at operator== prototype in public_key_type class declaration)
+      return rec->active_key() == fc::ecc::public_key(signature, hash);
+   }
+
    void client_impl::debug_start_simulated_time(const fc::time_point& starting_time)
    {
      bts::blockchain::start_simulated_time(starting_time);


### PR DESCRIPTION
The signatures produced by `wallet_sign_hash` are somewhat useless without any way to verify them.

This patch adds a command to verify the produced signatures.
