### PR TITLE
mkdir ./output if not exisit

### DIFF
--- a/libraries/api/ruby_generator/generate.rb
+++ b/libraries/api/ruby_generator/generate.rb
@@ -61,6 +61,7 @@ Dir['./templates/*.tmpl'].each do |template_file|
     puts "template '#{template_file}' couldn't be processed"
     next
   end
+  Dir.mkdir('./output') unless Dir.exists?('./output')
   output_file = "./output/#{$1}"
   print "processing #{template_file} -> #{output_file} ..  "
   $stdout.flush


### PR DESCRIPTION
Because libraries/api/ruby_generator/output is ignored in git repo, it's not available when someone takes a fresh pull and the generator will complain the output folder does not exist.
