### PR TITLE
Check that master key is properly decrypted

### DIFF
--- a/libraries/blockchain/include/bts/blockchain/extended_address.hpp
+++ b/libraries/blockchain/include/bts/blockchain/extended_address.hpp
@@ -83,6 +83,12 @@ namespace bts { namespace blockchain {
              return extended_public_key( fc::ecc::private_key::regenerate(priv_key).get_public_key(), 
                                          chain_code);
           }
+          
+          bool operator==( const extended_private_key& k ) const
+          {
+		      return (this->priv_key == k.priv_key) &&
+			         (this->chain_code == k.chain_code);
+		  }
 
           fc::ecc::private_key_secret  priv_key;
           fc::sha256                   chain_code;

--- a/libraries/wallet/wallet_records.cpp
+++ b/libraries/wallet/wallet_records.cpp
@@ -25,7 +25,8 @@ namespace bts { namespace wallet {
 
       // just to double check... we should find out if there is
       // a problem ASAP...
-      decrypt_key( password );
+      extended_private_key k_dec = decrypt_key( password );
+      FC_ASSERT( k_dec == k );
    } FC_CAPTURE_AND_RETHROW() }
 
    bool key_data::has_private_key()const


### PR DESCRIPTION
The code that encrypts the master key decrypts it again to check for problems, but doesn't do anything with the decrypted key.  So the only problem the check can find is if the decryption throws an exception.

This patch adds `FC_ASSERT` to check the decrypted key is the same as the original.

This compiles, but I haven't actually tested it yet.
