### PR TITLE
Refactor bts_create_key utility

### DIFF
--- a/programs/utils/CMakeLists.txt
+++ b/programs/utils/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable( btc_wallet_dump bitcoin_recovery.cpp )
 target_link_libraries( btc_wallet_dump fc bts_blockchain bts_utilities bitcoin )
 
 add_executable( bts_create_key bts_create_key.cpp )
-target_link_libraries( bts_create_key fc bts_blockchain bts_utilities)
+target_link_libraries( bts_create_key fc bts_blockchain bts_utilities deterministic_openssl_rand )
 
 add_executable( bts_create_genesis bts_create_genesis.cpp )
 target_link_libraries( bts_create_genesis fc bts_blockchain bts_utilities)

--- a/programs/utils/bts_create_key.cpp
+++ b/programs/utils/bts_create_key.cpp
@@ -1,21 +1,82 @@
+
+#include <boost/program_options.hpp>
+
 #include <bts/blockchain/address.hpp>
 #include <bts/blockchain/pts_address.hpp>
 #include <bts/blockchain/types.hpp>
+#include <bts/utilities/deterministic_openssl_rand.hpp>
 #include <bts/utilities/key_conversion.hpp>
+
 #include <fc/crypto/elliptic.hpp>
 #include <fc/io/json.hpp>
 #include <fc/reflect/variant.hpp>
 #include <fc/filesystem.hpp>
-#include<fc/variant_object.hpp>
+#include <fc/variant_object.hpp>
 
 #include <iostream>
 
 using namespace bts::blockchain;
 
-int main( int argc, char** argv )
+boost::program_options::variables_map parse_option_variables(int argc, char** argv)
 {
+    boost::program_options::positional_options_description p_option_config;
+    p_option_config.add("json-outfile", 1);
 
-    if( argc == 1 )
+    boost::program_options::options_description option_config("Usage");
+    option_config.add_options()
+        ("help", "Display this help message and exit")
+
+        ("json-outfile", boost::program_options::value<string>()->default_value(""), "Output file for private key data")
+
+        ("seed", boost::program_options::value<string>(), "Set seed for deterministic key generation")
+        ("count", boost::program_options::value<int64_t>()->default_value(-1), "Set number of keys to generate")
+        ;
+
+    boost::program_options::variables_map option_variables;
+    try
+    {
+        boost::program_options::store(
+                                      boost::program_options::command_line_parser(argc, argv)
+                                     .options(option_config)
+                                     .positional(p_option_config)
+                                     .run(),
+                                     option_variables
+                                     );
+        boost::program_options::notify(option_variables);
+    }
+    catch (boost::program_options::error& cmdline_error)
+    {
+        std::cerr << "Error: " << cmdline_error.what() << "\n";
+        std::cerr << option_config << "\n";
+        exit(1);
+    }
+
+    if (option_variables.count("help"))
+    {
+        std::cout << option_config << "\n";
+        exit(0);
+    }
+
+    return option_variables;
+}
+
+int run( int64_t index, fc::optional<string> seed, fc::optional<fc::path> json_outfile )
+{
+     if( seed.valid() )
+     {
+         string effective_seed;
+         if( index >= 0 )
+             effective_seed = (*seed)+std::to_string(index);
+         else
+             effective_seed = (*seed);
+         fc::sha512 hash_effective_seed = fc::sha512::hash(
+             effective_seed.c_str(),
+             effective_seed.length() );
+
+        bts::utilities::set_random_seed_for_testing(hash_effective_seed);
+    }
+    
+    if( !json_outfile.valid() )
     {
         auto key = fc::ecc::private_key::generate();
         auto obj = fc::mutable_variant_object();
@@ -26,18 +87,66 @@ int main( int argc, char** argv )
         obj["native_address"] = bts::blockchain::address(key.get_public_key());
         obj["pts_address"] = bts::blockchain::pts_address(key.get_public_key());
 
-        std::cout << fc::json::to_pretty_string(obj);
+        std::cout << fc::json::to_pretty_string(obj) << '\n';
         return 0;
     }
-    else if (argc == 2)
+    else
     {
-        std::cout << "writing new private key to JSON file " << argv[1] << "\n";
+        std::cout << "writing new private key to JSON file " << (*json_outfile).string() << "\n";
         fc::ecc::private_key key(fc::ecc::private_key::generate());
-        fc::json::save_to_file(key, fc::path(argv[1]));
+        fc::json::save_to_file(key, (*json_outfile));
 
         std::cout << "bts address: "
         << std::string(bts::blockchain::address(key.get_public_key())) << "\n";
 
         return 0;
     }
+}
+
+int main( int argc, char** argv )
+{
+    boost::program_options::variables_map option_variables =
+        parse_option_variables(argc, argv);
+
+    fc::optional<string> seed;
+    fc::optional<fc::path> json_outfile;
+    
+    if( option_variables.count("seed") )
+        seed = option_variables["seed"].as<string>();
+    if( option_variables.count("json-outfile") )
+    {
+        string s_json_outfile = option_variables["json-outfile"].as<string>();
+        if( s_json_outfile != "" )
+            json_outfile = fc::path(s_json_outfile);
+    }
+    
+    if( ! option_variables.count("count") )
+    {
+        std::cerr << "count undefined, should never happen!\n";
+        return 1;
+    }
+    
+    int n = option_variables["count"].as<int64_t>();
+    if( n != -1 )
+    {
+        if( json_outfile.valid() )
+        {
+            std::cerr << "Combining --count and --json-outfile is currently unsupported\n";
+            return 1;
+        }
+        std::cout << "[\n";
+        for( int64_t i=0; i<n; i++ )
+        {
+            if (i != 0)
+                std::cout << ",\n";
+            int result = run(i, seed, json_outfile);
+            if( result != 0 )
+                return result;
+        }
+        std::cout << "]\n";
+    }
+    else
+        return run(-1, seed, json_outfile);
+    
+    return 0;
 }


### PR DESCRIPTION
This pull request implements multiple related improvements to `bts_create_key` utility:
- Use boost::program_options to parse arguments
- Implement --seed parameter for deterministic key generation
- Implement --count parameter to generate a list of keys
