### PR TITLE
Dump config.hpp values as JSON with config_info RPC / --config-info option

### DIFF
--- a/libraries/client/client.cpp
+++ b/libraries/client/client.cpp
@@ -134,6 +134,8 @@ program_options::variables_map parse_option_variables(int argc, char** argv)
          ("log-commands", "Log all command input and output")
          ("ulog", program_options::value<bool>()->default_value( true ), "Enable CLI user logging")
 
+         ("blockchain-get-info", "Show result of blockchain_get_info and exit")
+
          ("growl", program_options::value<std::string>()->implicit_value("127.0.0.1"), "Send notifications about potential problems to Growl")
          ("growl-password", program_options::value<std::string>(), "Password for authenticating to a Growl server")
          ("growl-identifier", program_options::value<std::string>(), "A name displayed in growl messages to identify this bitshares_client instance")
@@ -162,6 +164,11 @@ program_options::variables_map parse_option_variables(int argc, char** argv)
    {
       std::cout << fc::json::to_pretty_string( bts::client::version_info() ) << "\n";
       exit(0);
+   }
+   else if (option_variables.count("blockchain-get-info"))
+   {
+	  std::cout << fc::json::to_pretty_string( bts::client::blockchain_get_info() ) << "\n";
+	  exit(0);
    }
 
    return option_variables;


### PR DESCRIPTION
I'm developing a Python testing script and I want to be able to access the `config.hpp` values so I don't hard code any assumptions about them into the tests.

So I made a quick shell / sed script to get the list of macro names, then hand-edited it to deal with `BTS_TEST_NETWORK`.  Then I implemented an RPC and dump-and-exit command line parameter to show the `config.hpp` values as JSON.

In the future we may want to make `config_info.hpp` generation more automated and integrated with the build process.  The eventual goal would be having it removed from the repo entirely and generated automatically during the build on all platforms.  But it will work well enough as-is for the foreseeable future, so this enhancement is very low priority.
