### PR TITLE
Remove ancient, unused print_banner()

### DIFF
--- a/libraries/client/client.cpp
+++ b/libraries/client/client.cpp
@@ -77,7 +77,6 @@ namespace bts { namespace client {
 
 const string BTS_MESSAGE_MAGIC = "BitShares Signed Message:\n";
 
-void print_banner();
 fc::logging_config create_default_logging_config( const fc::path&, bool enable_ulog );
 fc::path get_data_dir(const program_options::variables_map& option_variables);
 config load_config( const fc::path& datadir, bool enable_ulog );
@@ -193,21 +192,6 @@ string extract_commands_from_log_file(fc::path test_file)
       ulog("Extracting commands from input log file: ${log}",("log",test_file.string() ) );
    boost::filesystem::ifstream test_input(test_file);
    return extract_commands_from_log_stream(test_input);
-}
-
-
-void print_banner()
-{
-   std::cout<<"================================================================\n";
-   std::cout<<"=                                                              =\n";
-   std::cout<<"=             Welcome to BitShares "<< std::setw(5) << std::left << BTS_ADDRESS_PREFIX << "                       =\n";
-   std::cout<<"=                                                              =\n";
-   std::cout<<"=  This software is in alpha testing and is not suitable for   =\n";
-   std::cout<<"=  real monetary transactions or trading.  Use at your own     =\n";
-   std::cout<<"=  risk.                                                       =\n";
-   std::cout<<"=                                                              =\n";
-   std::cout<<"=  Type 'help' for usage information.                          =\n";
-   std::cout<<"================================================================\n";
 }
 
 fc::logging_config create_default_logging_config( const fc::path& data_dir, bool enable_ulog )


### PR DESCRIPTION
I noticed this function when I was looking at `client.cpp`, I think it has not been used in a long time and should be removed.
