### PR TITLE
Fix compiler warnings due to auto x = 0

### DIFF
--- a/libraries/blockchain/chain_database.cpp
+++ b/libraries/blockchain/chain_database.cpp
@@ -2605,8 +2605,8 @@ namespace bts { namespace blockchain {
    vector<market_order> chain_database::get_market_shorts( const string& quote_symbol,
                                                           uint32_t limit  )
    { try {
-       auto quote_id = get_asset_id( quote_symbol );
-       auto base_id  = 0;
+       asset_id_type quote_id = get_asset_id( quote_symbol );
+       asset_id_type base_id  = 0;
        if( base_id >= quote_id )
           FC_CAPTURE_AND_THROW( invalid_market, (quote_id)(base_id) );
 
@@ -2641,8 +2641,8 @@ namespace bts { namespace blockchain {
 
    vector<market_order> chain_database::get_market_covers( const string& quote_symbol, uint32_t limit )
    { try {
-       auto quote_asset_id = get_asset_id( quote_symbol );
-       auto base_asset_id  = 0;
+       asset_id_type quote_asset_id = get_asset_id( quote_symbol );
+       asset_id_type base_asset_id  = 0;
        if( base_asset_id >= quote_asset_id )
           FC_CAPTURE_AND_THROW( invalid_market, (quote_asset_id)(base_asset_id) );
 
@@ -2695,8 +2695,8 @@ namespace bts { namespace blockchain {
 
    share_type           chain_database::get_asset_collateral( const string& symbol )
    { try {
-       auto quote_asset_id = get_asset_id( symbol);
-       auto base_asset_id = 0;
+       asset_id_type quote_asset_id = get_asset_id( symbol);
+       asset_id_type base_asset_id = 0;
        auto total = share_type(0);
 
        auto market_itr = my->_collateral_db.lower_bound( market_index_key( price( 0, quote_asset_id, base_asset_id ) ) );

--- a/libraries/blockchain/chain_interface.cpp
+++ b/libraries/blockchain/chain_interface.cpp
@@ -233,7 +233,7 @@ namespace bts { namespace blockchain {
    string chain_interface::to_pretty_asset( const asset& a )const
    {
       const auto oasset = get_asset_record( a.asset_id );
-      const auto amount = ( a.amount >= 0 ) ? a.amount : -a.amount;
+      const share_type amount = ( a.amount >= 0 ) ? a.amount : -a.amount;
       if( oasset.valid() )
       {
          const auto precision = oasset->get_precision();

--- a/libraries/cli/pretty.cpp
+++ b/libraries/cli/pretty.cpp
@@ -491,7 +491,7 @@ string pretty_transaction_list( const vector<pretty_transaction>& transactions, 
         group = transaction.ledger_entries.size() > 1;
         if( group && !prev_group ) out << pretty_line( line_size + 2, '-' ) << "\n";
 
-        auto count = 0;
+        size_t count = 0;
         for( const auto& entry : transaction.ledger_entries )
         {
             const auto is_pending = !transaction.is_virtual && !transaction.is_confirmed;
@@ -612,7 +612,7 @@ string pretty_experimental_transaction_list( const set<pretty_transaction_experi
 
     for( const auto& transaction : transactions )
     {
-        auto line_count = 0;
+        size_t line_count = 0;
 
         while( line_count < transaction.inputs.size()
                || line_count < transaction.outputs.size()

--- a/libraries/cli/print_result.cpp
+++ b/libraries/cli/print_result.cpp
@@ -508,7 +508,7 @@ namespace bts { namespace cli {
       out << '-';
     out << '\n';
 
-    auto counter = 0;
+    int32_t counter = 0;
     for(const auto& acct : account_records)
     {
       if(acct.is_delegate())

--- a/libraries/wallet/transaction_ledger.cpp
+++ b/libraries/wallet/transaction_ledger.cpp
@@ -1346,7 +1346,7 @@ vector<wallet_transaction_record> wallet::get_transaction_history( const string&
    vector<wallet_transaction_record> history_records;
    const auto& transactions = my->_wallet_db.get_transactions();
 
-   auto asset_id = 0;
+   asset_id_type asset_id = 0;
    if( !asset_symbol.empty() && asset_symbol != BTS_BLOCKCHAIN_SYMBOL )
    {
        try

--- a/libraries/wallet/wallet_db.cpp
+++ b/libraries/wallet/wallet_db.cpp
@@ -899,7 +899,7 @@ namespace bts { namespace wallet {
    vector<wallet_balance_record> wallet_db::get_all_balances( const string& account_name, uint32_t limit )
    {
        auto ret = vector<wallet_balance_record>();
-       auto count = 0;
+       uint32_t count = 0;
        for( auto item : balances )
        {
            if (count == limit && limit != -1)


### PR DESCRIPTION
- Fixed problems found by `grep -R -n "auto.*=\\s*[0-9]" . --include="*.cpp"`
