### PR TITLE
Initial implementation of wallet_publish_feeds_multi_experimental

### DIFF
--- a/libraries/api/types.json
+++ b/libraries/api/types.json
@@ -393,6 +393,10 @@
          "cpp_return_type" : "std::pair<std::vector<bts::blockchain::market_order>,std::vector<bts::blockchain::market_order>>"
       },
       {
+         "type_name" : "vector<std::pair<string, wallet_transaction_record>>",
+         "cpp_return_type" : "std::vector<std::pair<std::string, bts::wallet::wallet_transaction_record>>"
+      },
+      {
         "type_name" : "amount",
         "cpp_parameter_type" : "int64_t",
         "cpp_return_type" : "int64_t",

--- a/libraries/api/wallet_api.json
+++ b/libraries/api/wallet_api.json
@@ -2290,6 +2290,18 @@
          "prerequisites" : ["wallet_unlocked"]
       },
       {
+         "method_name" : "wallet_publish_feeds_multi_experimental",
+         "description" : "publishes a set of feeds for BitAssets for all active delegates, most useful for testnets",
+         "return_type" : "vector<std::pair<string, wallet_transaction_record>>",
+         "parameters"  : [
+             {
+                "name" : "symbol_to_price_map",
+                "type" : "price_map",
+                "description" : "maps the BitAsset symbol to its price per share"
+             }
+         ],
+         "prerequisites" : ["wallet_unlocked"]
+      },      {
          "method_name" : "wallet_repair_records",
          "description" : "tries to repair any inconsistent wallet account, key, and transaction records",
          "return_type" : "void",

--- a/libraries/client/wallet_api.cpp
+++ b/libraries/client/wallet_api.cpp
@@ -1203,6 +1203,13 @@ wallet_transaction_record client_impl::wallet_publish_price_feed( const std::str
    network_broadcast_transaction( record.trx );
    return record;
 }
+
+vector<std::pair<string, wallet_transaction_record>> client_impl::wallet_publish_feeds_multi_experimental( const map<string,double>& real_amount_per_xts )
+{
+   const auto record_list = _wallet->publish_feeds_multi_experimental( real_amount_per_xts, true );
+   return record_list;
+}
+
 wallet_transaction_record client_impl::wallet_publish_feeds( const std::string& delegate_account,
                                                              const map<string,double>& real_amount_per_xts )
 {

--- a/libraries/wallet/include/bts/wallet/wallet.hpp
+++ b/libraries/wallet/include/bts/wallet/wallet.hpp
@@ -361,6 +361,11 @@ namespace bts { namespace wallet {
                  map<string,double> amount_per_xts,
                  bool sign
                  );
+         vector<std::pair<string, wallet_transaction_record>>
+                 publish_feeds_multi_experimental(
+                 map<string,double> amount_per_xts,
+                 bool sign
+                 );
          wallet_transaction_record publish_price(
                  const string& account,
                  double amount_per_xts,

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1659,6 +1659,30 @@ namespace detail {
    } FC_CAPTURE_AND_RETHROW() }
 
 
+   vector<std::pair<string, wallet_transaction_record>> wallet::publish_feeds_multi_experimental(
+           map<string,double> amount_per_xts, // map symbol to amount per xts
+           bool sign )
+   {
+	   vector<std::pair<string, wallet_transaction_record>> result;
+	   const vector<wallet_account_record> accounts = this->list_my_accounts();
+
+	   for( auto acct : accounts )
+	   {
+		   auto current_account = my->_blockchain->get_account_record( acct.name );
+		   if( !current_account )
+			   continue;
+		   if( !my->_blockchain->is_active_delegate( current_account->id ) )
+			   continue;
+	       wallet_transaction_record tr = this->publish_feeds(
+	           acct.name,
+	           amount_per_xts,
+	           sign);
+		   std::pair<string, wallet_transaction_record> p(acct.name, tr);
+		   result.push_back(p);
+	   }
+       return result;
+   }
+
    wallet_transaction_record wallet::publish_feeds(
            const string& account_to_publish_under,
            map<string,double> amount_per_xts, // map symbol to amount per xts


### PR DESCRIPTION
This commit implements a command which causes all accounts which are active delegates to publish a set of price feeds.

This is most useful for testnet environments, where often all delegates run on a single node.  Instead of needing to issue 101 commands to update 101 feeds, we can now simply issue a single command.
