### PR TITLE
Allow client_debug_name to be specified in config.json

### DIFF
--- a/libraries/cli/cli.cpp
+++ b/libraries/cli/cli.cpp
@@ -104,10 +104,13 @@ namespace bts { namespace cli {
             string get_prompt()const
             {
               string wallet_name =  _client->get_wallet()->get_wallet_name();
-              string prompt = wallet_name;
-              if( prompt == "" )
+              string prompt = "";
+              if( _client->get_client_debug_name() != "" )
+                 prompt += _client->get_client_debug_name() + ": ";
+              
+              if( wallet_name == "" )
               {
-                 prompt = "(wallet closed) " CLI_PROMPT_SUFFIX;
+                 prompt += "(wallet closed) " CLI_PROMPT_SUFFIX;
               }
               else
               {

--- a/libraries/client/client.cpp
+++ b/libraries/client/client.cpp
@@ -1793,6 +1793,11 @@ fc::ecc::public_key client_notification::signee() const
    return fc::ecc::public_key(signature, digest());
 }
 
+string client::get_client_debug_name() const
+{
+   return my->get_client_debug_name();
+}
+
 /**
   * Detail Implementation
   */

--- a/libraries/client/include/bts/client/client.hpp
+++ b/libraries/client/include/bts/client/client.hpp
@@ -72,7 +72,8 @@ namespace bts { namespace client {
           wallet_enabled(true),
           ignore_console(false),
           use_upnp(true),
-          maximum_number_of_connections(BTS_NET_DEFAULT_MAX_CONNECTIONS)
+          maximum_number_of_connections(BTS_NET_DEFAULT_MAX_CONNECTIONS),
+          client_debug_name("")
           {
 #ifdef BTS_TEST_NETWORK
               uint32_t port = BTS_NET_TEST_P2P_PORT + BTS_TEST_NETWORK_VERSION;
@@ -97,6 +98,7 @@ namespace bts { namespace client {
           uint16_t            maximum_number_of_connections;
           fc::logging_config  logging;
           string              wallet_callback_url;
+          string              client_debug_name;
 
           fc::optional<std::string> growl_notify_endpoint;
           fc::optional<std::string> growl_password;
@@ -139,6 +141,7 @@ namespace bts { namespace client {
          bts::rpc::rpc_server_ptr   get_rpc_server()const;
          bts::net::node_ptr         get_node()const;
          fc::path                   get_data_dir()const;
+         string                     get_client_debug_name()const;
 
          // returns true if the client is connected to the network
          bool                is_connected() const;
@@ -195,6 +198,7 @@ FC_REFLECT( bts::client::config,
             (rpc)(default_peers)(chain_servers)(chain_server)(mail_server_enabled)
             (wallet_enabled)(ignore_console)(logging)
             (wallet_callback_url)
+            (client_debug_name)
             (growl_notify_endpoint)
             (growl_password)
             (growl_bitshares_client_identifier) )

--- a/libraries/client/include/bts/client/client_impl.hpp
+++ b/libraries/client/include/bts/client/client_impl.hpp
@@ -200,6 +200,10 @@ public:
    bool on_new_transaction(const signed_transaction& trx);
    void blocks_too_old_monitor_task();
    void cancel_blocks_too_old_monitor_task();
+   string get_client_debug_name() const
+   {
+      return _config.client_debug_name;
+   }
 
    /* Implement node_delegate */
    // @{


### PR DESCRIPTION
The purpose of this commit is to specify a debug name for the client in the config file, which will be displayed in the prompt.

It might theoretically be useful for power users who frequently interact with multiple clients over CLI to add the client name to the prompt (to keep them from entering a command in the wrong client), but such users probably already use differently named wallets for the purpose if they care about that.

The reason I'm even spending time on this is that I'm working on improving our testing framework, and being able to use a string identifier to name multiple client objects in a single process will be quite useful for testing framework purposes.
