### PR TITLE
Update BUILD_OSX.md

### DIFF
--- a/BUILD_OSX.md
+++ b/BUILD_OSX.md
@@ -29,7 +29,7 @@ BitShares OS X Build Instructions
 
 7. Clone the BitShares repository:
    ```
-   git clone git@github.com:BitShares/bitshares.git
+   git clone https://github.com/BitShares/bitshares
    cd bitshares
    ```
 


### PR DESCRIPTION
The git@github: style of link to a github repository did not work for me in the command line, and may be broken or deprecated, at least on OS X.
